### PR TITLE
Updated content character encoding to use UTF-8.

### DIFF
--- a/src/main/java/nz/ac/auckland/cer/controllers/ContentController.java
+++ b/src/main/java/nz/ac/auckland/cer/controllers/ContentController.java
@@ -133,7 +133,7 @@ public class ContentController extends AbstractSearchController {
                 researchPhases, people, roleTypes, orgUnits));
     }
 
-    @RequestMapping(method = RequestMethod.GET, value = "/content/{id}")
+    @RequestMapping(method = RequestMethod.GET, value = "/content/{id}", produces={"application/json; charset=UTF-8"})
     @ApiOperation(value = "get a specific content item")
     public ResponseEntity<String> getContent(@PathVariable Integer id) throws JsonProcessingException {
         final Content item = contentRepository.findOne(id);


### PR DESCRIPTION
Fixes issues with special characters/macrons. Was previously using IEC_8859-1.

Solution was to update the `@RequestMapping()` annotation for `/content/{id}` to include the optional element `produces`, in which we specify the producible media types of the mapped request:

`@RequestMapping(method = RequestMethod.GET, value = "/content/{id}", produces={"application/json; charset=UTF-8"})`

