### PR TITLE
Use UTF-8 for all API endpoint responses

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -8,8 +8,3 @@ server.port=80
 spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS=false
 app.assets-location=file:/assets/
 app.enable-cors=False
-
-# Use UTF-8 for HTTP responses to support a wider set of characters.
-spring.http.encoding.charset=UTF-8
-spring.http.encoding.enabled=true
-spring.http.encoding.force=true

--- a/application.properties
+++ b/application.properties
@@ -12,3 +12,4 @@ app.enable-cors=False
 # Use UTF-8 for HTTP responses to support a wider set of characters.
 spring.http.encoding.charset=UTF-8
 spring.http.encoding.enabled=true
+spring.http.encoding.force=true

--- a/application.properties
+++ b/application.properties
@@ -8,3 +8,7 @@ server.port=80
 spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS=false
 app.assets-location=file:/assets/
 app.enable-cors=False
+
+# Use UTF-8 for HTTP responses to support a wider set of characters.
+spring.http.encoding.charset=UTF-8
+spring.http.encoding.enabled=true

--- a/src/main/java/nz/ac/auckland/cer/controllers/CategoryController.java
+++ b/src/main/java/nz/ac/auckland/cer/controllers/CategoryController.java
@@ -15,10 +15,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
+import org.springframework.http.MediaType;
 import java.util.List;
 
 
 @RestController
+@RequestMapping(produces=MediaType.APPLICATION_JSON_UTF8_VALUE)
 @Api(tags = {"Category"}, description = "Operations on category")
 public class CategoryController {
 

--- a/src/main/java/nz/ac/auckland/cer/controllers/ContentController.java
+++ b/src/main/java/nz/ac/auckland/cer/controllers/ContentController.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.UnsupportedEncodingException;
@@ -27,6 +28,7 @@ import java.util.List;
 
 
 @RestController
+@RequestMapping(produces=MediaType.APPLICATION_JSON_UTF8_VALUE)
 @Api(tags={"Content"}, description="Operations on content")
 public class ContentController extends AbstractSearchController {
 
@@ -133,7 +135,7 @@ public class ContentController extends AbstractSearchController {
                 researchPhases, people, roleTypes, orgUnits));
     }
 
-    @RequestMapping(method = RequestMethod.GET, value = "/content/{id}", produces={"application/json"})
+    @RequestMapping(method = RequestMethod.GET, value = "/content/{id}")
     @ApiOperation(value = "get a specific content item")
     public ResponseEntity<String> getContent(@PathVariable Integer id) throws JsonProcessingException {
         final Content item = contentRepository.findOne(id);

--- a/src/main/java/nz/ac/auckland/cer/controllers/ContentController.java
+++ b/src/main/java/nz/ac/auckland/cer/controllers/ContentController.java
@@ -133,7 +133,7 @@ public class ContentController extends AbstractSearchController {
                 researchPhases, people, roleTypes, orgUnits));
     }
 
-    @RequestMapping(method = RequestMethod.GET, value = "/content/{id}", produces={"application/json; charset=UTF-8"})
+    @RequestMapping(method = RequestMethod.GET, value = "/content/{id}", produces={"application/json"})
     @ApiOperation(value = "get a specific content item")
     public ResponseEntity<String> getContent(@PathVariable Integer id) throws JsonProcessingException {
         final Content item = contentRepository.findOne(id);

--- a/src/main/java/nz/ac/auckland/cer/controllers/GuideCategoryController.java
+++ b/src/main/java/nz/ac/auckland/cer/controllers/GuideCategoryController.java
@@ -13,10 +13,12 @@ import nz.ac.auckland.cer.repository.GuideCategoryRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 
 @RestController
+@RequestMapping(produces=MediaType.APPLICATION_JSON_UTF8_VALUE)
 @Api(tags={"GuideCategory"}, description="Operations on guide categories")
 public class GuideCategoryController {
 

--- a/src/main/java/nz/ac/auckland/cer/controllers/OrgUnitController.java
+++ b/src/main/java/nz/ac/auckland/cer/controllers/OrgUnitController.java
@@ -15,10 +15,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 
 @RestController
+@RequestMapping(produces=MediaType.APPLICATION_JSON_UTF8_VALUE)
 @Api(tags={"OrgUnit"}, description="Operations on an organisational unit")
 public class OrgUnitController {
 

--- a/src/main/java/nz/ac/auckland/cer/controllers/PersonController.java
+++ b/src/main/java/nz/ac/auckland/cer/controllers/PersonController.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.UnsupportedEncodingException;
@@ -27,6 +28,7 @@ import java.util.List;
 
 
 @RestController
+@RequestMapping(produces=MediaType.APPLICATION_JSON_UTF8_VALUE)
 @Api(tags = {"Person"}, description = "Operations on person")
 public class PersonController extends AbstractSearchController {
 

--- a/src/main/java/nz/ac/auckland/cer/controllers/PolicyController.java
+++ b/src/main/java/nz/ac/auckland/cer/controllers/PolicyController.java
@@ -9,11 +9,13 @@ import nz.ac.auckland.cer.sql.SqlQuery;
 import nz.ac.auckland.cer.sql.SqlStatement;
 import org.springframework.web.bind.annotation.*;
 
+import org.springframework.http.MediaType;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 
 
 @RestController
+@RequestMapping(produces=MediaType.APPLICATION_JSON_UTF8_VALUE)
 @Api(tags = {"Person"}, description = "Operations on person")
 public class PolicyController extends AbstractSearchController {
 

--- a/src/main/java/nz/ac/auckland/cer/controllers/SearchController.java
+++ b/src/main/java/nz/ac/auckland/cer/controllers/SearchController.java
@@ -14,6 +14,7 @@ import nz.ac.auckland.cer.sql.SqlStatement;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
+import org.springframework.http.MediaType;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.Query;
@@ -25,6 +26,7 @@ import java.util.List;
 
 
 @RestController
+@RequestMapping(produces=MediaType.APPLICATION_JSON_UTF8_VALUE)
 @Api(tags = {"Search"}, description = "Site wide search")
 public class SearchController {
 


### PR DESCRIPTION
By default, Spring MVC uses the legacy ISO-8859-1 charset as the content type for endpoints. This meant characters with macrons are not returned correctly, causing rendering errors. @Hganavak overrode the content endpoint to use UTF-8, but the same issue happened in other endpoints.

Spring Boot used to offer the setting in application properties to specify a charset for all endpoints. However, they have now changed its behaviour (see https://github.com/spring-projects/spring-boot/issues/5459)

I added the annotation `@RequestMapping` to each controller so all their endpoints use UTF-8 charset as encoding. New controllers will need the annotation as well. In the future, if we add an endpoint that returns images or other binary data to a controller, the encoding needs to be overridden. See https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/bind/annotation/RequestMapping.html#produces--